### PR TITLE
Fixing createClient deprecation warning

### DIFF
--- a/plugins/internal-redirect.js
+++ b/plugins/internal-redirect.js
@@ -26,8 +26,7 @@ exports.run = function(api) {
 	var rootRelUrl = pUrl.pathname;
 	if (pUrl.search) rootRelUrl += pUrl.search;
 
-	var client = HTTP.createClient(port, hostname);
-	var clientReq = client.request('GET', rootRelUrl, { host: hostname });
+    var clientReq = HTTP.request('GET', rootRelUrl, { host: hostname });
 	clientReq.end();
 	clientReq.on('response', function(resp) {
 		var hts = new HTS.HttpTransactionState();

--- a/test.js
+++ b/test.js
@@ -25,7 +25,11 @@ HTTP.createServer(function(req, resp){
 }).listen(8081);
 console.log('created test server');
 
-var cl = HTTP.createClient(8080, 'localhost');
+var options = {
+    hostname: 'localhost',
+    port: 8080
+};
+var req = HTTP.get(options);
 var req = cl.request('get', 'http://localhost:8081/', {host:'localhost'});
 req.end();
 


### PR DESCRIPTION
Hi.  Loving hoxy :).  Node.js has now deprecated http.createClient in favour of http.request so I have made a couple of changes to bring the code up-to-date.  Just wondering if you want to pull the changes in.  Many thanks for the great work.
