### PR TITLE
Some polish for hoxy.

### DIFF
--- a/index.html
+++ b/index.html
@@ -547,14 +547,21 @@
 </div>
 
 <div class="api-detail">
-  <h3 id="proxy-close"><a href="#proxy-close">proxy.close(<span class="args"></span>)</a></h3>
+  <h3 id="proxy-close"><a href="#proxy-close">proxy.close(<span class="args">[callback]</span>)</a></h3>
   <div class="api-detail-content">
     <p>
       Stops proxy receiving requests.
       Finalizes and/or cleans up any resources the proxy uses internally.
     </p>
     <pre class="language-javascript code">
-      proxy.close();
+      proxy.close(
+        function (err) {  // optional callback
+          if (err) {
+            throw err;
+          }
+          console.log('The proxy is no longer accepting new connections.');
+        }
+      );
     </pre>
   </div>
 </div>
@@ -1015,7 +1022,7 @@
             Accepted values:
             <ul>
               <li>
-                <code>replace</code> - 
+                <code>replace</code> -
                 (default)
                 Replaces the remote docroot with the local one.
                 In other words, if a requested file doesn't exist locally, it populates the response with a 404, even if it would have been found remotely.
@@ -1026,7 +1033,7 @@
                 In other words, if a requested file doesn't exist locally, it becomes a no-op, allowing the proxy to "see through" to the one on the remote server.
               </li>
               <li>
-                <code>mirror</code> - 
+                <code>mirror</code> -
                 Automatically mirror the remote docroot locally.
                 In other words, if a requested file doesn't exist locally, it's copied to the local docroot from the remote one, and will be found locally on subsequent requests.
               </li>

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -186,7 +186,7 @@ module.exports = Base.extend(function(opts){
   },
 
   close: function(){
-    this._server.close();
+    this._server.close.apply(this._server, arguments);
   },
 
   log: function(events, cb){

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.2.2",
   "author": "Greg Reimer <gregreimer@gmail.com>",
   "description": "Web-hacking proxy API for node",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:greim/hoxy.git"
+  },
   "bin": "./cli/hoxy-cli.js",
   "main": "./hoxy",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   },
   "bin": "./cli/hoxy-cli.js",
   "main": "./hoxy",
+  "scripts": {
+    "test": "node node_modules/.bin/mocha"
+  },
   "keywords": [
     "develop",
     "development",
@@ -34,6 +37,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "string-stream": "0.0.7"
+    "string-stream": "0.0.7",
+    "mocha": "2.1.x"
   }
 }

--- a/test/readme.md
+++ b/test/readme.md
@@ -1,7 +1,7 @@
 # Testing Hoxy
 
-Tests use [mocha](http://visionmedia.github.io/mocha/).
-
-    npm install -g mocha
-
-To run all tests, stand in the main project directory (the same one that contains `package.json`) and run the `mocha` command.
+To run all tests, stand anywhere inside of the project and do:
+````bash
+npm test
+````
+This will launch a suite of self-tests using [mocha](http://visionmedia.github.io/mocha/).


### PR DESCRIPTION
* No more npm warnings during npm install.
* Native args for .close(), to enable logging callbacks.
* Better testing setup, can be run from any subdirectory and without global installs.