### PR TITLE
Body.buffer getter always returns undefined

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -43,7 +43,7 @@ export default class Body extends EventEmitter {
 
   get buffer() {
     let src = this._source
-    return src ? src._buffers : undefined
+    return src ? src._buffer : undefined
   }
 
   set buffer(buffer) {


### PR DESCRIPTION
This change fixes a typo in the Body.buffer getter. It accesses a non-existent property and thus always returns undefined.