### PR TITLE
Delete content-encoding Header

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -139,7 +139,7 @@ export default class Body extends EventEmitter {
       }
       return streams.collect(readable)
       .then(buffer => {
-        this.headers['content-encoding'] = undefined
+        delete this.headers['content-encoding'];
         this._source = streams.from(buffer)
       })
     }


### PR DESCRIPTION
Noticed I was getting a `[Error: "name" and "value" are required for setHeader().]` error upon using `cycle.serve()` in a request intercept.
