### PR TITLE
No need to reject response on writable error.

### DIFF
--- a/src/cycle.js
+++ b/src/cycle.js
@@ -63,10 +63,15 @@ class ProvisionableRequest {
       opts.path = proxyPath
     }
     this._writable = h.request(opts, this._respProm.resolve)
+    this._writable.on('error', err => this._writableError = err);
   }
 
   send(readable) {
     return new Promise((resolve, reject) => {
+      if (this._writableError) {
+        reject(this._writableError);
+        return;
+      }
       this._writable.on('error', reject)
       if (!readable || typeof readable === 'string') {
         this._writable.end(readable || '', resolve)

--- a/src/cycle.js
+++ b/src/cycle.js
@@ -63,7 +63,6 @@ class ProvisionableRequest {
       opts.path = proxyPath
     }
     this._writable = h.request(opts, this._respProm.resolve)
-    //this._writable.on('error', this._respProm.reject)
   }
 
   send(readable) {

--- a/src/cycle.js
+++ b/src/cycle.js
@@ -63,7 +63,7 @@ class ProvisionableRequest {
       opts.path = proxyPath
     }
     this._writable = h.request(opts, this._respProm.resolve)
-    this._writable.on('error', this._respProm.reject)
+    //this._writable.on('error', this._respProm.reject)
   }
 
   send(readable) {

--- a/src/cycle.js
+++ b/src/cycle.js
@@ -63,16 +63,11 @@ class ProvisionableRequest {
       opts.path = proxyPath
     }
     this._writable = h.request(opts, this._respProm.resolve)
-    this._writable.on('error', err => this._writableError = err);
+    this._writable.on('error', this._respProm.reject);
   }
 
   send(readable) {
     return new Promise((resolve, reject) => {
-      if (this._writableError) {
-        reject(this._writableError);
-        return;
-      }
-      this._writable.on('error', reject)
       if (!readable || typeof readable === 'string') {
         this._writable.end(readable || '', resolve)
       } else {

--- a/src/cycle.js
+++ b/src/cycle.js
@@ -63,7 +63,7 @@ class ProvisionableRequest {
       opts.path = proxyPath
     }
     this._writable = h.request(opts, this._respProm.resolve)
-    this._writable.on('error', this._respProm.reject);
+    this._writable.on('error', this._respProm.reject)
   }
 
   send(readable) {

--- a/test/noserver.test.js
+++ b/test/noserver.test.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2015 by Greg Reimer <gregreimer@gmail.com>
+ * MIT License. See mit-license.txt for more info.
+ */
+
+//import assert from 'assert'
+//import send from './lib/send'
+//import wait from '../src/wait'
+//import co from 'co'
+import hoxy from '../src/main';
+import http from 'http'
+
+describe('non-existent servers', function(){
+
+  it('should foo', done => {
+
+    const proxy = hoxy.createServer({
+      reverse: 'http://sdfkjhsdfdgjhhfs.example.com:8888',
+    })
+    proxy.listen(function() {
+      const { address, port } = proxy.address()
+      http.get({
+        hostname: address,
+        port: port,
+        path: '/',
+      }, () => {
+        done(new Error('callback not expected'))
+      }).on('error', done)
+    })
+    proxy.on('error', () => {
+      done()
+    })
+  })
+})

--- a/test/noserver.test.js
+++ b/test/noserver.test.js
@@ -3,11 +3,7 @@
  * MIT License. See mit-license.txt for more info.
  */
 
-//import assert from 'assert'
-//import send from './lib/send'
-//import wait from '../src/wait'
-//import co from 'co'
-import hoxy from '../src/main';
+import hoxy from '../src/main'
 import http from 'http'
 
 describe('non-existent servers', function(){

--- a/test/noserver.test.js
+++ b/test/noserver.test.js
@@ -8,10 +8,10 @@ import http from 'http'
 
 describe('non-existent servers', function(){
 
-  it('should foo', done => {
+  it('should emit an error when forwarding a request to a non-existent server', done => {
 
     const proxy = hoxy.createServer({
-      reverse: 'http://sdfkjhsdfdgjhhfs.example.com:8888',
+      reverse: 'http://sdfkjhsdfdgjhhfs:8888',
     })
     proxy.listen(function() {
       const { address, port } = proxy.address()


### PR DESCRIPTION
If there's an error on the writable, it will be handled during the `send()` operation.