### PR TITLE
Makes `cheerio` an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "await": "^0.2.5",
     "babel-runtime": "^5.7.0",
     "bluebird": "^2.9.34",
-    "cheerio": "^0.19.0",
     "co": "^4.5.4",
     "colors": "^1.1.2",
     "lodash": "^3.10.0",
@@ -43,6 +42,9 @@
     "route-pattern": "^0.0.6",
     "stream-throttle": "^0.1.3",
     "ugly-adapter": "^1.1.0"
+  },
+  "optionalDependencies": {
+    "cheerio": "^0.19.0"
   },
   "license": "MIT",
   "devDependencies": {

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -23,7 +23,11 @@ let asHandlers = {
     // TODO: test to ensure that parse errors here fail gracefully.
     let contentType = r.headers['content-type']
     let isXml = isTypeXml(contentType)
-    r.$ = cheerio.load(r._source.toString(), { xmlMode: isXml })
+    if (cheerio) {
+      r.$ = cheerio.load(r._source.toString(), {xmlMode: isXml})
+    } else {
+      throw new Error("In order to intercept as jQuery DOM object, 'cheerio' must be installed")
+    }
   },
   'json': r => {
     // TODO: test to ensure that parse errors here propagate to error log.


### PR DESCRIPTION
Not all `hoxy` users need to intercept as `$`, and `cheerio` is a massive dependency: `> 10MB`.
So, in this PR, it's an optional dependency. By default, `npm install hoxy` will still include it. However, `npm install hoxy --no-optional` will not include it.

I made `hoxy` throw an error when intercepting as `$` without `cheerio`, so it makes sense when the interception fails.

Finally, this is a separate PR from #82 so that you can pick and choose which dependency reductions are OK
