### PR TITLE
listen for http.request error

### DIFF
--- a/src/proxy.js
+++ b/src/proxy.js
@@ -241,6 +241,8 @@ export default class Proxy extends EventEmitter {
         }, fromServer => {
           toClient.writeHead(fromServer.statusCode, fromServer.headers)
           fromServer.pipe(toClient)
+        }).on('error', function(e) {
+          console.error('proxy error', e);
         })
         fromClient.pipe(toServer)
       })


### PR DESCRIPTION
Was running into 

```js
events.js:163
      throw er; // Unhandled 'error' event
      ^

Error: socket hang up
    at createHangUpError (_http_client.js:302:15)
    at Socket.socketOnEnd (_http_client.js:394:23)
    at emitNone (events.js:91:20)
    at Socket.emit (events.js:188:7)
    at endReadableNT (_stream_readable.js:975:12)
    at _combinedTickCallback (internal/process/next_tick.js:80:11)
    at process._tickCallback (internal/process/next_tick.js:104:9)
```

Found the issue via this SO thread:
> [whenever you emit an 'error' event and no one listens to it, it will throw. ](http://stackoverflow.com/questions/10814481/how-to-debug-a-socket-hang-up-error-in-nodejs)

In this case the culprit seems to be the [`http.request`](https://github.com/greim/hoxy/blob/1e7d50ae833d1358bf1cf2e24daad9694d9b3a68/src/proxy.js#L235) that's missing a listener for the error

Should fix https://github.com/greim/hoxy/issues/60