### PR TITLE
Fix NET::ERR_CERT_COMMON_NAME_INVALID error in Chrome 58 and up

### DIFF
--- a/src/sni-spoofer.js
+++ b/src/sni-spoofer.js
@@ -42,6 +42,7 @@ export class SNISpoofer extends EventEmitter {
         locality: 'Provo',
         organization: 'ACME Tech Inc',
         commonName: serverName,
+        altNames: [serverName],
         serviceKey: rootKey,
         serviceCertificate: rootCert,
         serial: Date.now(),


### PR DESCRIPTION
For Chrome 58 and later, only the subjectAlternativeName extension, not commonName, is used to match the domain name and site certificate.
https://support.google.com/chrome/a/answer/7391219?hl=en

Should fix #94