### PR TITLE
Use this._reverse instead of opts.reverse

### DIFF
--- a/src/proxy.js
+++ b/src/proxy.js
@@ -159,7 +159,7 @@ export default class Proxy extends EventEmitter {
       cycle.on('log', log => this.emit('log', log))
 
       co.call(this, function*() {
-        req._setHttpSource(fromClient, opts.reverse)
+        req._setHttpSource(fromClient, this._reverse)
         try { yield this._runIntercepts('request', cycle) }
         catch(ex) { this._emitError(ex, 'request') }
         let partiallyFulfilledRequest = yield cycle._sendToServer()


### PR DESCRIPTION
To allow to programmatically control the URL we are reverse proxying after creating an instance of the proxy, use the attribute `this._reverse` instead of the command line opts.reverse.

Example Use Case:

```
proxy.intercept({
  phase: 'request',
  mimeType: 'text/html',
  as: '$'
}, (req, resp, cycle) => {
  if (resp.$('something') == 'something') {
    proxy._reverse = 'https://www.reddit.com'; // next request will proxy reddit.com instead
  }
});
```