### PR TITLE
Pass errors from MITM SSL sockets up to the proxy object

### DIFF
--- a/src/proxy.js
+++ b/src/proxy.js
@@ -217,8 +217,10 @@ export default class Proxy extends EventEmitter {
       })
 
       this._server.on('connect', (request, clientSocket, head) => {
+        clientSocket.on('error', err => this.emit('error', err))
         let addr = this._tlsSpoofingServer.address()
         let serverSocket = net.connect(addr.port, addr.address, () => {
+          serverSocket.on('error', err => this.emit('error', err))
           clientSocket.write(cxnEstablished)
           serverSocket.write(head)
           clientSocket


### PR DESCRIPTION
This PR passes socket errors from the SSL MITM code path up to the the top level Proxy object so they may be handled externally. 

Without this fix, I was seeing `ECONNRESET` errors bubble up as uncaught errors which could only be handled with a `process.on('uncaughtException', .....)` block.  I believe the source of these errors is  random client disconnects when using hoxy in a cross browser testing environment via selenium. 

I didn't see an obvious way to introduce tests for this in the current test suite, if I've missed something here please point me in the right direction and I'll add them. 