### PR TITLE
 fix: update to @dabh/colors for security vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "bluebird": "^2.9.34",
     "cheerio": "^0.19.0",
     "co": "^4.5.4",
-    "colors": "^1.1.2",
+    "@dabh/colors": "^1.1.2",
     "lodash": "^3.10.0",
     "minimist": "^1.1.1",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
A Security Vuln was identified in the Colors package for >1.4.0, offending packages being `1.4.1`, `1.4.44-liberty`
- [source1](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source2](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source3](https://security.snyk.io/vuln/SNYK-JS-COLORS-2331906)

This PR updates the color package to using [@dabh/colors](https://www.npmjs.com/package/@dabh/colors) as stated on this [colors issue #317](https://github.com/Marak/colors.js/issues/317#issue-1098535594) which is a safe alternative.